### PR TITLE
Update README related to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Shun Sakai <sorairolake@protonmail.ch>"]
 edition = "2018"
 description = "A utility for computing various message digests"
-readme = "README.adoc"
 repository = "https://github.com/sorairolake/rshash"
 license = "GPL-3.0-or-later"
 categories = ["command-line-utilities"]

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,17 @@ toc::[]
 
 == Installation
 
+=== Via a package manager
+
+|===
+|OS |Method |Package |Command
+
+|Any
+|Cargo
+|https://crates.io/crates/rshash[`rshash`]
+|`cargo install rshash`
+|===
+
 === How to build and install
 
 Please see the link:BUILD.adoc[Build Guide].

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,9 @@
 = RSHash
 :toc: macro
 
-image::https://github.com/sorairolake/rshash/workflows/CI/badge.svg[CI, link=https://github.com/sorairolake/rshash/actions?query=workflow%3ACI]
+image:https://github.com/sorairolake/rshash/workflows/CI/badge.svg[CI, link=https://github.com/sorairolake/rshash/actions?query=workflow%3ACI]
+image:https://img.shields.io/crates/v/rshash[Version, link=https://crates.io/crates/rshash]
+image:https://img.shields.io/crates/l/rshash[License, link=https://www.gnu.org/licenses/gpl-3.0.html]
 
 *RSHash* is a command-line utility for computing and checking various message digests.
 


### PR DESCRIPTION
Remove the `readme` field from `Cargo.toml` because crates.io doesn't support rendering AsciiDoc.